### PR TITLE
Delegate calls by references instead of by value in `#[union_fn]` macro expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,3 +316,57 @@ const _: () = {
     }
 };
 ```
+
+## Generated Assembly
+
+Below is the generated assembly for the `Call[WithContext]` trait according to
+the [Compiler Explorer](https://rust.godbolt.org/) for the generated user facing
+`enum` and the call-optimized `opt` types for the above `Counter` example:
+
+### `Call[WithContext] for <enum>`
+
+```asm
+<example::Counter as example::union_fn::CallWithContext>::call:
+        sub     rsp, 40
+        mov     rax, qword ptr [rdi]
+        test    rax, rax
+        je      .LBB3_8
+        cmp     eax, 1
+        jne     .LBB3_6
+        movups  xmm0, xmmword ptr [rdi + 8]
+        movups  xmm1, xmmword ptr [rdi + 24]
+        movaps  xmmword ptr [rsp + 16], xmm1
+        movaps  xmmword ptr [rsp], xmm0
+        mov     rax, qword ptr [rsi]
+        cmp     rax, 3
+        ja      .LBB3_3
+        mov     rax, qword ptr [rsp + 8*rax]
+        mov     qword ptr [rsi], rax
+        add     rsp, 40
+        ret
+.LBB3_8:
+        mov     rax, qword ptr [rdi + 8]
+        add     qword ptr [rsi], rax
+        add     rsp, 40
+        ret
+.LBB3_6:
+        mov     qword ptr [rsi], 0
+        add     rsp, 40
+        ret
+.LBB3_3:
+        xor     eax, eax
+        mov     qword ptr [rsi], rax
+        add     rsp, 40
+        ret
+```
+
+### `Call[WithContext] for <opt>`
+
+```asm
+<example::_::CounterOpt as example::union_fn::CallWithContext>::call:
+        mov     rax, rsi
+        mov     rcx, qword ptr [rdi]
+        lea     rsi, [rdi + 8]
+        mov     rdi, rax
+        jmp     rcx
+```

--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -104,7 +104,7 @@ impl UnionFn {
             let tuple_bindings = make_tuple_type(method_span, &bindings);
             quote_spanned!(method_span=>
                 #( #method_attrs )*
-                fn #method_ident( #ctx_param args: <#trait_ident as ::union_fn::UnionFn>::Args )
+                fn #method_ident( #ctx_param args: &<#trait_ident as ::union_fn::UnionFn>::Args )
                     -> <#trait_ident as ::union_fn::UnionFn>::Output
                 {
                     let #tuple_bindings = unsafe { args.#method_ident };
@@ -142,7 +142,7 @@ impl UnionFn {
             #[doc = #opt_docs]
             #[derive(::core::marker::Copy, ::core::clone::Clone)]
             pub struct #ident_opt {
-                handler: fn(#ctx <#trait_ident as ::union_fn::UnionFn>::Args) -> <#trait_ident as ::union_fn::UnionFn>::Output,
+                handler: fn(#ctx &<#trait_ident as ::union_fn::UnionFn>::Args) -> <#trait_ident as ::union_fn::UnionFn>::Output,
                 args: <#trait_ident as ::union_fn::UnionFn>::Args,
             }
 
@@ -332,7 +332,7 @@ impl UnionFn {
                         type Context = #context;
 
                         fn call(self, ctx: &mut Self::Context) -> <#ident as ::union_fn::UnionFn>::Output {
-                            (self.handler)(ctx, self.args)
+                            (self.handler)(ctx, &self.args)
                         }
                     }
                 )
@@ -341,7 +341,7 @@ impl UnionFn {
                 quote_spanned!(span=>
                     impl ::union_fn::Call for #ident_opt {
                         fn call(self) -> <#ident as ::union_fn::UnionFn>::Output {
-                            (self.handler)(self.args)
+                            (self.handler)(&self.args)
                         }
                     }
                 )


### PR DESCRIPTION
According to the compiler explorer this significantly improves the Rust/LLVM codegen of the `Call[WithContext]` impl of the generated `opt` type.
In essence the `Call[WithContext]` impl turns into a tail call under `--release` settings independent of the `Args` type in use by the `#[union_fn]` macro invocation.

## Generated Assembly

Below is the generated assembly for the `opt` type for the `CallWithContext` trait:
(Note: According to the Compiler Explorer the generated assembly for the `enum` type does not change.)

### BEFORE

```asm
<example::_::CounterOpt as example::union_fn::CallWithContext>::call:
        sub     rsp, 40
        mov     rax, rsi
        mov     rcx, qword ptr [rdi]
        movups  xmm0, xmmword ptr [rdi + 8]
        movups  xmm1, xmmword ptr [rdi + 24]
        movaps  xmmword ptr [rsp + 16], xmm1
        movaps  xmmword ptr [rsp], xmm0
        mov     rsi, rsp
        mov     rdi, rax
        call    rcx
        add     rsp, 40
        ret
```

### This PR

```asm
<example::_::CounterOpt as example::union_fn::CallWithContext>::call:
        mov     rax, rsi
        mov     rcx, qword ptr [rdi]
        lea     rsi, [rdi + 8]
        mov     rdi, rax
        jmp     rcx
```